### PR TITLE
make card optional

### DIFF
--- a/src/CashierToolController.php
+++ b/src/CashierToolController.php
@@ -69,7 +69,7 @@ class CashierToolController extends Controller
 
         return [
             'user' => $billable->toArray(),
-            'cards' => request('brief') ? [] : $this->formatCards($billable->cards(), $billable->defaultCard()->id),
+            'cards' => request('brief') ? [] : $this->formatCards($billable->cards(), optional($billable->defaultCard())->id),
             'invoices' => request('brief') ? [] : $this->formatInvoices($billable->invoicesIncludingPending()),
             'charges' => request('brief') ? [] : $this->formatCharges($billable->asStripeCustomer()->charges()),
             'subscription' => $this->formatSubscription($subscription, $stripeSubscription),


### PR DESCRIPTION
you can create a subscription to a free plan with a `null` token

```php
$account->newSubscription('default', 'free-plan')->create(null);
```

when you do so and the controller expects a card, it 500s 

